### PR TITLE
Move URL variable declaration

### DIFF
--- a/feature-demos/skill-demo-videoapp-directive/lambda/custom/index.js
+++ b/feature-demos/skill-demo-videoapp-directive/lambda/custom/index.js
@@ -3,7 +3,7 @@ const Alexa = require('ask-sdk-core');
 const HELP_MESSAGE = 'This is a simple demo. Just open the skill to see the video.';
 const ERROR_MESSAGE = 'Sorry, an error occurred in the demo. Please check the logs.';
 const STOP_MESSAGE = 'Goodbye!';
-const videoUrl = 'https://s3.amazonaws.com/ask-samples-resources/videos/underconfirmation.mp4';
+// NOTE: set the video url location below
 
 function supportsVideo(handlerInput) {
   const hasVideo =
@@ -23,6 +23,12 @@ const LaunchRequestHandler = {
     return request.type === 'LaunchRequest';
   },
   handle(handlerInput) {
+    // video location
+    const videoUrl = 'https://s3.amazonaws.com/ask-samples-resources/videos/underconfirmation.mp4';
+    // Use this isntead if you want to use your own video and your skill is Alexa-hosted. Be sure to require the util.js file
+    // const util = require('util.js');
+    // const videoUrl = util.getS3PreSignedUrl('Media/myVideo.mp4');
+    
     if (supportsVideo(handlerInput)) {
       handlerInput.responseBuilder.addVideoAppLaunchDirective(videoUrl, 'Video Sample Title', 'Video Subtitle');
 


### PR DESCRIPTION
Move the url variable declaration into the Launch Handler. This will prevent errors if the sample is mostly used as-is and videoUrl is set to a presigned URL to a developer supplied video hosted in an Alexa-hosted skill.  The pre-signed URL expires after a minute, so if the Lambda container's lifetime is longer than one minute, then the skill response will vend an expired URL. This would be fine (simply check the logs, fix the problem), however the error message is only on the client side (i.e. Echo Show) with nothing in CloudWatch logs, making it hard to debug, especially for someone new to skill development.

<!-- general checklist  -->
### Tests/checks which any code/configuration submission will need to pass
- [ X ] Adheres to any applicable [code style guidelines](../tree/master/guides/style) including linting
- [ X ] Code is i18n-ready (does not need to be translated/localized)
- [ X ] Does not utilize practices which would prevent certification
- [ ] `ask deploy` successfully deploys skill and is ready for use
  > setup steps which are not achievable through the ASK CLI are exempted from this requirement
  > If multiple runtime languages are included, skill.json should use node.js or python version. 
- [ ] Works in all locales for which interaction models have been supplied
- [ ] Works on all devices (including simulator) which support any required features (special requirements must be called out in the README)
- [ ] Documents any dependencies in the README
- [ ] PR does not include any code dependencies (just includes the package.json, pom.xml, etc.)

<!--- * * * * * * * * * * * * --->
<!--- Do not delete the following section or your PR will be closed without comment. --->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
